### PR TITLE
[Chapter4] Add Conway-game example implemented on PyCUDA.

### DIFF
--- a/conway_gpu.py
+++ b/conway_gpu.py
@@ -1,0 +1,7 @@
+import pycuda.autoinit
+import pycuda.driver as drv
+from pycuda import gpuarray
+from pycuda.compiler import SourceModule
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation


### PR DESCRIPTION
This PR adds example of PyCUDA using threads and blocks. The example implements the Conway game of life.