### PR TITLE
[Chapter10] Fix launch_printf-script by fixing the path to libc.

### DIFF
--- a/chapter10/launch_printf.py
+++ b/chapter10/launch_printf.py
@@ -1,6 +1,6 @@
 # This simplest example shows how to load a 'printf' function from a libc.so shared library usign python.
 
 import ctypes
-libc = ctypes.CDLL('/lib/i386-linux-gnu/libc.so.6')
-libc.printf("Hellow from ctypes!\n")
+libc = ctypes.CDLL('/lib/x86_64-linux-gnu/libc-2.27.so')
+libc.printf("Hello from ctypes!\n")
 libc.printf("Pi is approximately %f.\n", ctypes.c_double(3.14))


### PR DESCRIPTION
This PR fixes the launchprintf script by updating the path to the valid libc library (X86-64). In order to correctly launch, needs to be used with 'sudo'.